### PR TITLE
Maybe fix bot_api being importable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from distutils.core import setup
+import setuptools
+
 setup(name='bot_api',
       version='0.5',
-      py_modules=['bot_api'],
       url="https://github.com/cml-cs-iastate/bot_api",
       author="iastate",
+      packages=setuptools.find_packages(),
       author_email="gurgalex@iastate.edu"
       )


### PR DESCRIPTION
`bot_api` was not importable when installing in docker file.
Maybe this fixes it.